### PR TITLE
fix: filter prerelease tags from major/minor release version comparisons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,16 +131,16 @@ Config
 
 **Version info flags** (all booleans, all available in templates):
 
-| Flag                               | Meaning                                                                              |
-| ---------------------------------- | ------------------------------------------------------------------------------------ |
-| `isSnapshotVersion`                | Commit has no tag                                                                    |
-| `isTaggedVersion`                  | Commit has a tag (any)                                                               |
-| `isSemVerVersion`                  | Tag is valid semver                                                                  |
-| `isReleaseSemVerVersion`           | Semver tag with no prerelease/build metadata                                         |
-| `isHighestSemVerVersion`           | Highest semver tag in entire repo                                                    |
-| `isHighestSemVerReleaseVersion`    | Highest release (non-prerelease) tag in repo                                         |
-| `isHighestSameMajorReleaseVersion` | This is a release tag AND it is the highest semver tag within the same major version |
-| `isHighestSameMinorReleaseVersion` | This is a release tag AND it is the highest semver tag within the same major.minor   |
+| Flag                               | Meaning                                                        |
+| ---------------------------------- | -------------------------------------------------------------- |
+| `isSnapshotVersion`                | Commit has no tag                                              |
+| `isTaggedVersion`                  | Commit has a tag (any)                                         |
+| `isSemVerVersion`                  | Tag is valid semver                                            |
+| `isReleaseSemVerVersion`           | Semver tag with no prerelease/build metadata                   |
+| `isHighestSemVerVersion`           | Highest semver tag in entire repo                              |
+| `isHighestSemVerReleaseVersion`    | Highest release (non-prerelease) tag in repo                   |
+| `isHighestSameMajorReleaseVersion` | Highest release (non-prerelease) tag within same major version |
+| `isHighestSameMinorReleaseVersion` | Highest release (non-prerelease) tag within same major.minor   |
 
 **Snapshot base version**: When no previous release exists, defaults to `0.0.0`. The default `prefixTpl` bumps the minor: `0.0.0` -> `0.1.0-`.
 

--- a/README.md
+++ b/README.md
@@ -257,16 +257,16 @@ Exit codes: `0` success, `2` unexpected error, `3` configuration validation erro
 
 Every run outputs these boolean flags, which can be used to drive downstream CI logic:
 
-| Flag                                        | Meaning                                                                        |
-| ------------------------------------------- | ------------------------------------------------------------------------------ |
-| `GTS_IS_SNAPSHOT_VERSION`                   | Commit has no tag (snapshot build)                                             |
-| `GTS_IS_TAGGED_VERSION`                     | Commit has a tag                                                               |
-| `GTS_IS_SEMVER_VERSION`                     | Tag is a valid semver version                                                  |
-| `GTS_IS_RELEASE_SEMVER_VERSION`             | Semver tag with no prerelease or build metadata                                |
-| `GTS_IS_HIGHEST_SEMVER_VERSION`             | Highest semver tag in the entire repo                                          |
-| `GTS_IS_HIGHEST_SEMVER_RELEASE_VERSION`     | Highest release (non-prerelease) tag in the repo                               |
-| `GTS_IS_HIGHEST_SAME_MAJOR_RELEASE_VERSION` | This is a release tag and the highest semver tag within the same major version |
-| `GTS_IS_HIGHEST_SAME_MINOR_RELEASE_VERSION` | This is a release tag and the highest semver tag within the same major.minor   |
+| Flag                                        | Meaning                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| `GTS_IS_SNAPSHOT_VERSION`                   | Commit has no tag (snapshot build)                                 |
+| `GTS_IS_TAGGED_VERSION`                     | Commit has a tag                                                   |
+| `GTS_IS_SEMVER_VERSION`                     | Tag is a valid semver version                                      |
+| `GTS_IS_RELEASE_SEMVER_VERSION`             | Semver tag with no prerelease or build metadata                    |
+| `GTS_IS_HIGHEST_SEMVER_VERSION`             | Highest semver tag in the entire repo                              |
+| `GTS_IS_HIGHEST_SEMVER_RELEASE_VERSION`     | Highest release (non-prerelease) tag in the repo                   |
+| `GTS_IS_HIGHEST_SAME_MAJOR_RELEASE_VERSION` | Highest release (non-prerelease) tag within the same major version |
+| `GTS_IS_HIGHEST_SAME_MINOR_RELEASE_VERSION` | Highest release (non-prerelease) tag within the same major.minor   |
 
 ## Further Reading
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -42,16 +42,16 @@ All templates have access to these variables:
 
 ### `versionInfo` — Version classification flags
 
-| Variable                                       | Type      | Description                                                                    |
-| ---------------------------------------------- | --------- | ------------------------------------------------------------------------------ |
-| `versionInfo.isSnapshotVersion`                | `boolean` | Commit has no tag                                                              |
-| `versionInfo.isTaggedVersion`                  | `boolean` | Commit has a tag (any)                                                         |
-| `versionInfo.isSemVerVersion`                  | `boolean` | Tag is a valid semver version                                                  |
-| `versionInfo.isReleaseSemVerVersion`           | `boolean` | Semver tag with no prerelease or build metadata                                |
-| `versionInfo.isHighestSemVerVersion`           | `boolean` | Highest semver tag in the entire repository                                    |
-| `versionInfo.isHighestSemVerReleaseVersion`    | `boolean` | Highest release tag in the repository                                          |
-| `versionInfo.isHighestSameMajorReleaseVersion` | `boolean` | This is a release tag and the highest semver tag within the same major version |
-| `versionInfo.isHighestSameMinorReleaseVersion` | `boolean` | This is a release tag and the highest semver tag within the same major.minor   |
+| Variable                                       | Type      | Description                                                        |
+| ---------------------------------------------- | --------- | ------------------------------------------------------------------ |
+| `versionInfo.isSnapshotVersion`                | `boolean` | Commit has no tag                                                  |
+| `versionInfo.isTaggedVersion`                  | `boolean` | Commit has a tag (any)                                             |
+| `versionInfo.isSemVerVersion`                  | `boolean` | Tag is a valid semver version                                      |
+| `versionInfo.isReleaseSemVerVersion`           | `boolean` | Semver tag with no prerelease or build metadata                    |
+| `versionInfo.isHighestSemVerVersion`           | `boolean` | Highest semver tag in the entire repository                        |
+| `versionInfo.isHighestSemVerReleaseVersion`    | `boolean` | Highest release tag in the repository                              |
+| `versionInfo.isHighestSameMajorReleaseVersion` | `boolean` | Highest release (non-prerelease) tag within the same major version |
+| `versionInfo.isHighestSameMinorReleaseVersion` | `boolean` | Highest release (non-prerelease) tag within the same major.minor   |
 
 ### `config` — Current strategy configuration
 

--- a/src/version/versionResolver.test.ts
+++ b/src/version/versionResolver.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, mock } from "bun:test";
+import semver from "semver";
+
+import type { Config } from "../config/types";
+import type { Platform } from "../platform";
+import { resolveVersion } from "./versionResolver";
+import { VersionStrategy } from "./versionStrategy";
+
+// Mock git utilities before importing the module under test
+const mockListTags = mock(() => [] as string[]);
+const mockListTagsBeforeCommit = mock((_sha: string) => [] as string[]);
+const mockGetCommitDateTime = mock((_sha: string) => "20240101120000");
+
+mock.module("../util/git", () => ({
+  listTags: mockListTags,
+  listTagsBeforeCommit: mockListTagsBeforeCommit,
+  getCommitDateTime: mockGetCommitDateTime,
+}));
+
+function createMockPlatform(overrides: Partial<Platform> = {}): Platform {
+  return {
+    type: "test",
+    isSupported: () => true,
+    getCommitSha: () => "abc123",
+    getCommitRefName: () => "main",
+    getGitTag: () => undefined,
+    getChangeRequestIdentifier: () => undefined,
+    ...overrides,
+  };
+}
+
+function createMinimalConfig(): Config {
+  return {
+    platform: "auto",
+    defaults: {
+      branchPrefixes: [],
+      snapshot: {
+        defaultBranches: ["main"],
+        useChangeRequestIdentifier: true,
+        prefixTpl:
+          "{{ commitInfo.previousSemVerReleaseVersion | semver_inc: 'minor' | append: '-' }}",
+        suffixTpl: "",
+        branchIdentifierTpl: "",
+        commitIdentifierTpl:
+          "{{ commitInfo.dateTime }}.{{ commitInfo.sha | truncate: 12, '' }}",
+        versionTpl:
+          "{{ prefix }}{{ branchIdentifier }}{{ commitIdentifier }}{{ suffix }}",
+      },
+      tags: { enabled: false, snapshot: [], tagged: [], semVer: [] },
+      properties: {},
+    },
+    strategies: {
+      test: {
+        enabled: true,
+        snapshot: {
+          defaultBranches: ["main"],
+          useChangeRequestIdentifier: true,
+          prefixTpl:
+            "{{ commitInfo.previousSemVerReleaseVersion | semver_inc: 'minor' | append: '-' }}",
+          suffixTpl: "",
+          branchIdentifierTpl: "",
+          commitIdentifierTpl:
+            "{{ commitInfo.dateTime }}.{{ commitInfo.sha | truncate: 12, '' }}",
+          versionTpl:
+            "{{ prefix }}{{ branchIdentifier }}{{ commitIdentifier }}{{ suffix }}",
+        },
+        tags: { enabled: false, snapshot: [], tagged: [], semVer: [] },
+        properties: {},
+      },
+    },
+    output: {
+      type: "env",
+      env: { prefix: "GTS_", arrayDelimiter: " ", quoteArrays: false },
+    },
+  } as Config;
+}
+
+describe("versionResolver", () => {
+  describe("isHighestSameMajorReleaseVersion", () => {
+    it("should be true when release tag is highest release in its major, ignoring prereleases", () => {
+      // Tags: v1.0.0 (release), v1.1.0-beta.1 (prerelease)
+      // Building v1.0.0 — should be highest major=1 release
+      mockListTags.mockReturnValue(["v1.0.0", "v1.1.0-beta.1"]);
+      mockListTagsBeforeCommit.mockReturnValue(["v1.0.0"]);
+
+      const platform = createMockPlatform({
+        getGitTag: () => "v1.0.0",
+      });
+
+      const config = createMinimalConfig();
+      const strategies = [new VersionStrategy("test", config.strategies.test)];
+      const result = resolveVersion(config, platform, strategies);
+
+      expect(result.isReleaseSemVerVersion).toBe(true);
+      expect(result.isHighestSameMajorReleaseVersion).toBe(true);
+    });
+
+    it("should be false when a higher release exists in the same major", () => {
+      // Tags: v1.0.0, v1.1.0 — both releases
+      // Building v1.0.0 — v1.1.0 is higher
+      mockListTags.mockReturnValue(["v1.0.0", "v1.1.0"]);
+      mockListTagsBeforeCommit.mockReturnValue(["v1.0.0"]);
+
+      const platform = createMockPlatform({
+        getGitTag: () => "v1.0.0",
+      });
+
+      const config = createMinimalConfig();
+      const strategies = [new VersionStrategy("test", config.strategies.test)];
+      const result = resolveVersion(config, platform, strategies);
+
+      expect(result.isReleaseSemVerVersion).toBe(true);
+      expect(result.isHighestSameMajorReleaseVersion).toBe(false);
+    });
+  });
+
+  describe("isHighestSameMinorReleaseVersion", () => {
+    it("should be true when release tag is highest release in its minor, ignoring prereleases", () => {
+      // Tags: v1.0.0 (release), v1.0.1-rc.1 (prerelease)
+      // Building v1.0.0 — should be highest minor=1.0 release
+      mockListTags.mockReturnValue(["v1.0.0", "v1.0.1-rc.1"]);
+      mockListTagsBeforeCommit.mockReturnValue(["v1.0.0"]);
+
+      const platform = createMockPlatform({
+        getGitTag: () => "v1.0.0",
+      });
+
+      const config = createMinimalConfig();
+      const strategies = [new VersionStrategy("test", config.strategies.test)];
+      const result = resolveVersion(config, platform, strategies);
+
+      expect(result.isReleaseSemVerVersion).toBe(true);
+      expect(result.isHighestSameMinorReleaseVersion).toBe(true);
+    });
+
+    it("should be false when a higher release exists in the same minor", () => {
+      // Tags: v1.0.0, v1.0.1 — both releases
+      // Building v1.0.0 — v1.0.1 is higher
+      mockListTags.mockReturnValue(["v1.0.0", "v1.0.1"]);
+      mockListTagsBeforeCommit.mockReturnValue(["v1.0.0"]);
+
+      const platform = createMockPlatform({
+        getGitTag: () => "v1.0.0",
+      });
+
+      const config = createMinimalConfig();
+      const strategies = [new VersionStrategy("test", config.strategies.test)];
+      const result = resolveVersion(config, platform, strategies);
+
+      expect(result.isReleaseSemVerVersion).toBe(true);
+      expect(result.isHighestSameMinorReleaseVersion).toBe(false);
+    });
+  });
+});

--- a/src/version/versionResolver.ts
+++ b/src/version/versionResolver.ts
@@ -143,17 +143,24 @@ const resolveTaggedVersion = (
     isReleaseSemVerVersion &&
     isHighestTagInList(semVerTags.filter((t) => isReleaseSemVerTag(t)));
 
-  // is it the highest same major semver tag in the repository?
+  // is it the highest same major semver release tag in the repository?
   const isHighestSameMajorReleaseVersion =
     isReleaseSemVerVersion &&
-    isHighestTagInList(semVerTags.filter((t) => t.major === version.major));
+    isHighestTagInList(
+      semVerTags.filter(
+        (t) => isReleaseSemVerTag(t) && t.major === version.major,
+      ),
+    );
 
-  // is it the highest same minor semver tag in the repository?
+  // is it the highest same minor semver release tag in the repository?
   const isHighestSameMinorReleaseVersion =
     isReleaseSemVerVersion &&
     isHighestTagInList(
       semVerTags.filter(
-        (t) => t.major == version.major && t.minor === version.minor,
+        (t) =>
+          isReleaseSemVerTag(t) &&
+          t.major === version.major &&
+          t.minor === version.minor,
       ),
     );
 


### PR DESCRIPTION
## Summary

- `isHighestSameMajorReleaseVersion` and `isHighestSameMinorReleaseVersion` now filter to release-only tags when comparing, consistent with `isHighestSemVerReleaseVersion`
- Previously, a prerelease tag like `v1.2.0-beta.1` would prevent `v1.1.0` from being recognized as the highest release in major 1
- Adds unit tests for `versionResolver` with mocked git utilities to cover this scenario
- Updates flag descriptions in AGENTS.md, README.md, and docs/templates.md

Fixes #52

## Test plan

- [x] `bun test src/version/versionResolver.test.ts` — new unit tests pass
- [x] `bun test` — full suite (96 tests) passes
- [x] Verify prerelease tags no longer block release tag from being "highest same major/minor"