### PR TITLE
chore: add scheduled cleanup for old Docker snapshot images

### DIFF
--- a/.github/workflows/cleanup-docker-images.yml
+++ b/.github/workflows/cleanup-docker-images.yml
@@ -21,4 +21,4 @@ jobs:
           package-type: container
           min-versions-to-keep: 20
           delete-only-untagged-versions: false
-          ignore-versions: "^(latest|main|\\d+|\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)$"
+          ignore-versions: "^(latest|main|\\d+|\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+(-.+)?)$"


### PR DESCRIPTION
## Summary

- Adds a weekly workflow (Sunday 03:00 UTC) to clean up old Docker snapshot images from ghcr.io
- Uses `actions/delete-package-versions@v5` (official GitHub action)
- Keeps release tags (`1`, `1.0`, `1.0.0`, `latest`) via `ignore-versions` regex
- Always keeps the 10 most recent versions regardless
- Can also be triggered manually via `workflow_dispatch`