### PR TITLE
ci: remove Trivy container scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
 
     steps:
       - name: Checkout repository
@@ -224,17 +223,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Trivy container scan
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: sarif
-          output: trivy-results.sarif
-
-      - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
- Remove Trivy scan steps from docker-build job
- Remove `security-events: write` permission from docker-build job
- CodeQL remains for source code analysis

## Why
Container image scanning needs more thought on how to properly integrate without redundant builds. Removing for now to keep CI clean.