### PR TITLE
feat: add git and manual platform adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,15 +66,20 @@ index.ts                          CLI entry point (Commander.js)
 
 ## CLI Options
 
-| Option               | Short | Default                | Env Var             | Description                                  |
-| -------------------- | ----- | ---------------------- | ------------------- | -------------------------------------------- |
-| `--config-file`      | `-f`  | `git-that-semver.yaml` | `GTS_CONFIG_FILE`   | Config file path                             |
-| `--config-value`     | `-c`  | `[]`                   |                     | Override config values (`path.to.key=value`) |
-| `--log-level`        |       | `INFO`                 | `GTS_LOG_LEVEL`     | `TRACE\|DEBUG\|INFO\|WARN\|ERROR\|SILENT`    |
-| `--enable-strategy`  | `-e`  | `[]`                   |                     | Enable strategies by name                    |
-| `--disable-strategy` | `-d`  | `[]`                   |                     | Disable strategies by name                   |
-| `--output-format`    | `-o`  | `env`                  | `GTS_OUTPUT_FORMAT` | `env\|json\|yaml`                            |
-| `--dump-config`      |       | `false`                |                     | Dump resolved config and exit                |
+| Option                | Short | Default                | Env Var                 | Description                                         |
+| --------------------- | ----- | ---------------------- | ----------------------- | --------------------------------------------------- |
+| `--config-file`       | `-f`  | `git-that-semver.yaml` | `GTS_CONFIG_FILE`       | Config file path                                    |
+| `--config-value`      | `-c`  | `[]`                   |                         | Override config values (`path.to.key=value`)        |
+| `--log-level`         |       | `INFO`                 | `GTS_LOG_LEVEL`         | `TRACE\|DEBUG\|INFO\|WARN\|ERROR\|SILENT`           |
+| `--enable-strategy`   | `-e`  | `[]`                   |                         | Enable strategies by name                           |
+| `--disable-strategy`  | `-d`  | `[]`                   |                         | Disable strategies by name                          |
+| `--output-format`     | `-o`  | `env`                  | `GTS_OUTPUT_FORMAT`     | `env\|json\|yaml`                                   |
+| `--platform`          |       | (from config)          | `GTS_PLATFORM`          | Platform type (`auto\|github\|gitlab\|git\|manual`) |
+| `--commit-sha`        |       |                        | `GTS_COMMIT_SHA`        | Commit SHA (manual platform)                        |
+| `--ref-name`          |       |                        | `GTS_REF_NAME`          | Branch/tag name (manual platform)                   |
+| `--git-tag`           |       |                        | `GTS_GIT_TAG`           | Git tag (manual platform)                           |
+| `--change-request-id` |       |                        | `GTS_CHANGE_REQUEST_ID` | Change request ID (manual platform)                 |
+| `--dump-config`       |       | `false`                |                         | Dump resolved config and exit                       |
 
 Exit codes: `0` success, `2` unexpected error, `3` Zod validation error.
 
@@ -92,7 +97,7 @@ Strategy configs inherit from `defaults` (deep merge, except `branchPrefixes`). 
 
 ```
 Config
-  platform: "auto" | "github" | "gitlab"
+  platform: "auto" | "github" | "gitlab" | "git" | "manual"
   defaults: DefaultConfig
     branchPrefixes: string[]           # stripped from branch names (e.g. "feature/")
     snapshot: SnapshotConfig
@@ -181,10 +186,12 @@ Uses LiquidJS. Templates are defined in config YAML (both defaults and per-strat
 
 **Auto-detection** (`platform: auto`): tries GitHub, then GitLab; throws if neither matches.
 
-| Platform       | Detection                         | SHA             | Ref Name                                                             | Tag                                        | Change Request                                                     |
-| -------------- | --------------------------------- | --------------- | -------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
-| GitHub Actions | `CI=true` + `GITHUB_ACTIONS=true` | `GITHUB_SHA`    | `GITHUB_HEAD_REF` (PR, via `GITHUB_EVENT_NAME`) or `GITHUB_REF_NAME` | `GITHUB_REF_NAME` if `GITHUB_REF_TYPE=tag` | `pr-{N}` from `GITHUB_REF` (when `GITHUB_EVENT_NAME=pull_request`) |
-| GitLab CI      | `CI=true` + `GITLAB_CI=true`      | `CI_COMMIT_SHA` | `CI_COMMIT_REF_NAME`                                                 | `CI_COMMIT_TAG`                            | `mr-{N}` from `CI_MERGE_REQUEST_IID`                               |
+| Platform       | Detection                         | SHA                  | Ref Name                                                             | Tag                                        | Change Request                                                     |
+| -------------- | --------------------------------- | -------------------- | -------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| GitHub Actions | `CI=true` + `GITHUB_ACTIONS=true` | `GITHUB_SHA`         | `GITHUB_HEAD_REF` (PR, via `GITHUB_EVENT_NAME`) or `GITHUB_REF_NAME` | `GITHUB_REF_NAME` if `GITHUB_REF_TYPE=tag` | `pr-{N}` from `GITHUB_REF` (when `GITHUB_EVENT_NAME=pull_request`) |
+| GitLab CI      | `CI=true` + `GITLAB_CI=true`      | `CI_COMMIT_SHA`      | `CI_COMMIT_REF_NAME`                                                 | `CI_COMMIT_TAG`                            | `mr-{N}` from `CI_MERGE_REQUEST_IID`                               |
+| Git            | Explicit (`--platform git`)       | `git rev-parse HEAD` | `git branch --show-current`                                          | `git describe --tags --exact-match HEAD`   | Always `undefined`                                                 |
+| Manual         | Explicit or auto (when flags set) | `--commit-sha` / env | `--ref-name` / env                                                   | `--git-tag` / env                          | `--change-request-id` / env                                        |
 
 ## Output Formats
 

--- a/index.ts
+++ b/index.ts
@@ -130,8 +130,8 @@ try {
   );
   const manualOpts = hasManualOpts
     ? {
-        sha: opts.commitSha!,
-        refName: opts.refName!,
+        sha: opts.commitSha ?? "",
+        refName: opts.refName ?? "",
         tag: opts.gitTag,
         changeRequestId: opts.changeRequestId,
       }

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import { ZodError } from "zod";
 import { resolveConfig } from "./src/config";
 import { style, LogLevel, logger } from "./src/logging";
 import { resolveOutputPrinter } from "./src/output";
-import { resolvePlatform } from "./src/platform";
+import { allPlatformTypes, resolvePlatform } from "./src/platform";
 import { resolveVersion } from "./src/version/versionResolver";
 import { resolveStrategies } from "./src/version/versionStrategy";
 
@@ -57,7 +57,7 @@ const program = new Command("git-that-semver")
   .addOption(
     new Option("--platform <platform>", "Platform type")
       .env("GTS_PLATFORM")
-      .choices(["auto", "github", "gitlab", "git", "manual"] as const),
+      .choices(["auto", ...allPlatformTypes] as const),
   )
   .addOption(
     new Option("--commit-sha <sha>", "Commit SHA (manual platform)").env(

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,32 @@ const program = new Command("git-that-semver")
       .default("env")
       .choices(["env", "json", "yaml"] as const),
   )
+  .addOption(
+    new Option("--platform <platform>", "Platform type")
+      .env("GTS_PLATFORM")
+      .choices(["auto", "github", "gitlab", "git", "manual"] as const),
+  )
+  .addOption(
+    new Option("--commit-sha <sha>", "Commit SHA (manual platform)").env(
+      "GTS_COMMIT_SHA",
+    ),
+  )
+  .addOption(
+    new Option("--ref-name <name>", "Branch/tag name (manual platform)").env(
+      "GTS_REF_NAME",
+    ),
+  )
+  .addOption(
+    new Option("--git-tag <tag>", "Git tag (manual platform)").env(
+      "GTS_GIT_TAG",
+    ),
+  )
+  .addOption(
+    new Option(
+      "--change-request-id <id>",
+      "Change request identifier (manual platform)",
+    ).env("GTS_CHANGE_REQUEST_ID"),
+  )
   .option("--dump-config", "Dump configuration for debug purposes")
   .configureOutput({
     writeErr: (str) =>
@@ -93,7 +119,25 @@ try {
     process.exit(0);
   }
 
-  const platform = resolvePlatform(config.platform);
+  const opts = program.opts();
+  const platformType = opts.platform ?? config.platform;
+
+  const hasManualOpts = !!(
+    opts.commitSha ||
+    opts.refName ||
+    opts.gitTag ||
+    opts.changeRequestId
+  );
+  const manualOpts = hasManualOpts
+    ? {
+        sha: opts.commitSha!,
+        refName: opts.refName!,
+        tag: opts.gitTag,
+        changeRequestId: opts.changeRequestId,
+      }
+    : undefined;
+
+  const platform = resolvePlatform(platformType, manualOpts);
   const strategies = resolveStrategies(config.strategies);
   const result = resolveVersion(config, platform, strategies);
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { specificPlatformTypes } from "../platform";
+import { allPlatformTypes } from "../platform";
 
 export const FreeformProperties = z.record(z.string(), z.string());
 
@@ -55,7 +55,7 @@ export const OutputConfig = z.object({
 
 export const Config = z.object({
   defaults: DefaultConfig.prefault({}),
-  platform: z.enum(["auto", ...specificPlatformTypes]).default("auto"),
+  platform: z.enum(["auto", ...allPlatformTypes]).default("auto"),
   tagPrefix: z.string().default(""),
   strategies: z.record(
     z

--- a/src/platform/git.test.ts
+++ b/src/platform/git.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+
+import { executeCommand as realExecuteCommand } from "../util/process";
 
 const mockExecuteCommand = mock();
 
@@ -7,6 +9,18 @@ mock.module("../util/process", () => ({
 }));
 
 const { GitPlatform } = await import("./git");
+
+afterEach(() => {
+  mockExecuteCommand.mockReset();
+});
+
+// Restore the real module after all tests in this file
+// to avoid poisoning other test files
+afterAll(() => {
+  mock.module("../util/process", () => ({
+    executeCommand: realExecuteCommand,
+  }));
+});
 
 describe("Git Platform", () => {
   const platform = new GitPlatform();

--- a/src/platform/git.test.ts
+++ b/src/platform/git.test.ts
@@ -1,54 +1,33 @@
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
-import { executeCommand as realExecuteCommand } from "../util/process";
-
-const mockExecuteCommand = mock();
-
-mock.module("../util/process", () => ({
-  executeCommand: mockExecuteCommand,
-}));
-
-const { GitPlatform } = await import("./git");
-
-afterEach(() => {
-  mockExecuteCommand.mockReset();
-});
-
-// Restore the real module after all tests in this file
-// to avoid poisoning other test files
-afterAll(() => {
-  mock.module("../util/process", () => ({
-    executeCommand: realExecuteCommand,
-  }));
-});
+import { GitPlatform } from "./git";
 
 describe("Git Platform", () => {
-  const platform = new GitPlatform();
+  const mockExec = mock();
+  const platform = new GitPlatform(mockExec);
+
+  afterEach(() => {
+    mockExec.mockReset();
+  });
 
   test("identifies as git platform", () => {
     expect(platform.type).toBe("git");
   });
 
   test("returns commit SHA from git rev-parse HEAD", () => {
-    mockExecuteCommand.mockReturnValueOnce(
-      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-    );
+    mockExec.mockReturnValueOnce("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2");
 
     expect(platform.getCommitSha()).toBe(
       "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     );
-    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
-      "git",
-      "rev-parse",
-      "HEAD",
-    ]);
+    expect(mockExec).toHaveBeenLastCalledWith(["git", "rev-parse", "HEAD"]);
   });
 
   test("returns branch name from git branch --show-current", () => {
-    mockExecuteCommand.mockReturnValueOnce("feature/my-branch");
+    mockExec.mockReturnValueOnce("feature/my-branch");
 
     expect(platform.getCommitRefName()).toBe("feature/my-branch");
-    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+    expect(mockExec).toHaveBeenLastCalledWith([
       "git",
       "branch",
       "--show-current",
@@ -56,12 +35,12 @@ describe("Git Platform", () => {
   });
 
   test("falls back to git rev-parse --abbrev-ref HEAD on detached HEAD", () => {
-    mockExecuteCommand
+    mockExec
       .mockReturnValueOnce("") // git branch --show-current returns empty
       .mockReturnValueOnce("HEAD"); // git rev-parse --abbrev-ref HEAD
 
     expect(platform.getCommitRefName()).toBe("HEAD");
-    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+    expect(mockExec).toHaveBeenLastCalledWith([
       "git",
       "rev-parse",
       "--abbrev-ref",
@@ -70,10 +49,10 @@ describe("Git Platform", () => {
   });
 
   test("returns tag from git describe --tags --exact-match", () => {
-    mockExecuteCommand.mockReturnValueOnce("v1.2.3");
+    mockExec.mockReturnValueOnce("v1.2.3");
 
     expect(platform.getGitTag()).toBe("v1.2.3");
-    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+    expect(mockExec).toHaveBeenLastCalledWith([
       "git",
       "describe",
       "--tags",
@@ -83,7 +62,7 @@ describe("Git Platform", () => {
   });
 
   test("returns undefined when HEAD is not tagged", () => {
-    mockExecuteCommand.mockImplementationOnce(() => {
+    mockExec.mockImplementationOnce(() => {
       throw new Error("fatal: no tag exactly matches");
     });
 

--- a/src/platform/git.test.ts
+++ b/src/platform/git.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import { GitPlatform } from "./git";
+const mockExecuteCommand = mock();
+
+mock.module("../util/process", () => ({
+  executeCommand: mockExecuteCommand,
+}));
+
+const { GitPlatform } = await import("./git");
 
 describe("Git Platform", () => {
   const platform = new GitPlatform();
@@ -9,19 +15,65 @@ describe("Git Platform", () => {
     expect(platform.type).toBe("git");
   });
 
-  test("returns commit SHA as 40-char hex string", () => {
-    const sha = platform.getCommitSha();
-    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  test("returns commit SHA from git rev-parse HEAD", () => {
+    mockExecuteCommand.mockReturnValueOnce(
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    );
+
+    expect(platform.getCommitSha()).toBe(
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    );
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+      "git",
+      "rev-parse",
+      "HEAD",
+    ]);
   });
 
-  test("returns current branch name", () => {
-    const refName = platform.getCommitRefName();
-    expect(refName.length).toBeGreaterThan(0);
+  test("returns branch name from git branch --show-current", () => {
+    mockExecuteCommand.mockReturnValueOnce("feature/my-branch");
+
+    expect(platform.getCommitRefName()).toBe("feature/my-branch");
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+      "git",
+      "branch",
+      "--show-current",
+    ]);
   });
 
-  test("returns string or undefined for git tag", () => {
-    const tag = platform.getGitTag();
-    expect(tag === undefined || typeof tag === "string").toBe(true);
+  test("falls back to git rev-parse --abbrev-ref HEAD on detached HEAD", () => {
+    mockExecuteCommand
+      .mockReturnValueOnce("") // git branch --show-current returns empty
+      .mockReturnValueOnce("HEAD"); // git rev-parse --abbrev-ref HEAD
+
+    expect(platform.getCommitRefName()).toBe("HEAD");
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+      "git",
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
+  });
+
+  test("returns tag from git describe --tags --exact-match", () => {
+    mockExecuteCommand.mockReturnValueOnce("v1.2.3");
+
+    expect(platform.getGitTag()).toBe("v1.2.3");
+    expect(mockExecuteCommand).toHaveBeenLastCalledWith([
+      "git",
+      "describe",
+      "--tags",
+      "--exact-match",
+      "HEAD",
+    ]);
+  });
+
+  test("returns undefined when HEAD is not tagged", () => {
+    mockExecuteCommand.mockImplementationOnce(() => {
+      throw new Error("fatal: no tag exactly matches");
+    });
+
+    expect(platform.getGitTag()).toBeUndefined();
   });
 
   test("always returns undefined for change request identifier", () => {

--- a/src/platform/git.test.ts
+++ b/src/platform/git.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { GitPlatform } from "./git";
+
+describe("Git Platform", () => {
+  const platform = new GitPlatform();
+
+  test("identifies as git platform", () => {
+    expect(platform.type).toBe("git");
+  });
+
+  test("returns commit SHA as 40-char hex string", () => {
+    const sha = platform.getCommitSha();
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("returns current branch name", () => {
+    const refName = platform.getCommitRefName();
+    expect(refName.length).toBeGreaterThan(0);
+  });
+
+  test("returns string or undefined for git tag", () => {
+    const tag = platform.getGitTag();
+    expect(tag === undefined || typeof tag === "string").toBe(true);
+  });
+
+  test("always returns undefined for change request identifier", () => {
+    expect(platform.getChangeRequestIdentifier()).toBeUndefined();
+  });
+});

--- a/src/platform/git.ts
+++ b/src/platform/git.ts
@@ -1,0 +1,37 @@
+import type { Platform } from "../platform";
+import { executeCommand } from "../util/process";
+
+export class GitPlatform implements Platform {
+  type = "git";
+
+  getCommitSha(): string {
+    return executeCommand(["git", "rev-parse", "HEAD"]);
+  }
+
+  getCommitRefName(): string {
+    const branch = executeCommand(["git", "branch", "--show-current"]);
+    if (branch.length > 0) {
+      return branch;
+    }
+
+    return executeCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
+  }
+
+  getGitTag(): string | undefined {
+    try {
+      return executeCommand([
+        "git",
+        "describe",
+        "--tags",
+        "--exact-match",
+        "HEAD",
+      ]);
+    } catch {
+      return undefined;
+    }
+  }
+
+  getChangeRequestIdentifier(): string | undefined {
+    return undefined;
+  }
+}

--- a/src/platform/git.ts
+++ b/src/platform/git.ts
@@ -1,25 +1,34 @@
 import type { Platform } from "../platform";
-import { executeCommand } from "../util/process";
+import * as processUtil from "../util/process";
 
 export class GitPlatform implements Platform {
   type = "git";
 
   getCommitSha(): string {
-    return executeCommand(["git", "rev-parse", "HEAD"]);
+    return processUtil.executeCommand(["git", "rev-parse", "HEAD"]);
   }
 
   getCommitRefName(): string {
-    const branch = executeCommand(["git", "branch", "--show-current"]);
+    const branch = processUtil.executeCommand([
+      "git",
+      "branch",
+      "--show-current",
+    ]);
     if (branch.length > 0) {
       return branch;
     }
 
-    return executeCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
+    return processUtil.executeCommand([
+      "git",
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ]);
   }
 
   getGitTag(): string | undefined {
     try {
-      return executeCommand([
+      return processUtil.executeCommand([
         "git",
         "describe",
         "--tags",

--- a/src/platform/git.ts
+++ b/src/platform/git.ts
@@ -1,40 +1,29 @@
 import type { Platform } from "../platform";
-import * as processUtil from "../util/process";
+import { executeCommand as defaultExecuteCommand } from "../util/process";
+
+type CommandExecutor = (parts: string[]) => string;
 
 export class GitPlatform implements Platform {
   type = "git";
 
+  constructor(private exec: CommandExecutor = defaultExecuteCommand) {}
+
   getCommitSha(): string {
-    return processUtil.executeCommand(["git", "rev-parse", "HEAD"]);
+    return this.exec(["git", "rev-parse", "HEAD"]);
   }
 
   getCommitRefName(): string {
-    const branch = processUtil.executeCommand([
-      "git",
-      "branch",
-      "--show-current",
-    ]);
+    const branch = this.exec(["git", "branch", "--show-current"]);
     if (branch.length > 0) {
       return branch;
     }
 
-    return processUtil.executeCommand([
-      "git",
-      "rev-parse",
-      "--abbrev-ref",
-      "HEAD",
-    ]);
+    return this.exec(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
   }
 
   getGitTag(): string | undefined {
     try {
-      return processUtil.executeCommand([
-        "git",
-        "describe",
-        "--tags",
-        "--exact-match",
-        "HEAD",
-      ]);
+      return this.exec(["git", "describe", "--tags", "--exact-match", "HEAD"]);
     } catch {
       return undefined;
     }

--- a/src/platform/github.ts
+++ b/src/platform/github.ts
@@ -1,7 +1,7 @@
-import type { Platform } from "../platform";
+import type { AutoDetectablePlatform } from "../platform";
 import { requiredEnv } from "../util/env";
 
-export class GitHubPlatform implements Platform {
+export class GitHubPlatform implements AutoDetectablePlatform {
   type = "github";
 
   getGitTag(): string | undefined {

--- a/src/platform/gitlab.ts
+++ b/src/platform/gitlab.ts
@@ -1,7 +1,7 @@
-import type { Platform } from "../platform";
+import type { AutoDetectablePlatform } from "../platform";
 import { env, requiredEnv } from "../util/env";
 
-export class GitLabPlatform implements Platform {
+export class GitLabPlatform implements AutoDetectablePlatform {
   type = "gitlab";
 
   getGitTag(): string | undefined {

--- a/src/platform/index.test.ts
+++ b/src/platform/index.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { resolvePlatform, specificPlatformTypes } from "./index";
+import {
+  allPlatformTypes,
+  resolvePlatform,
+  specificPlatformTypes,
+} from "./index";
 
 describe("Platform Resolution", () => {
   const originalEnv = process.env;
@@ -25,6 +29,25 @@ describe("Platform Resolution", () => {
     expect(platform.type).toBe("gitlab");
   });
 
+  test("resolves git platform when specified", () => {
+    const platform = resolvePlatform("git");
+    expect(platform.type).toBe("git");
+  });
+
+  test("resolves manual platform when specified with options", () => {
+    const platform = resolvePlatform("manual", {
+      sha: "abc123",
+      refName: "main",
+    });
+    expect(platform.type).toBe("manual");
+  });
+
+  test("throws when manual platform specified without options", () => {
+    expect(() => resolvePlatform("manual")).toThrow(
+      "Manual platform requires --commit-sha and --ref-name",
+    );
+  });
+
   test("throws on unknown platform", () => {
     expect(() => resolvePlatform("unknown")).toThrow(
       "Unknown platform: unknown",
@@ -47,6 +70,16 @@ describe("Platform Resolution", () => {
     expect(platform.type).toBe("gitlab");
   });
 
+  test("auto-resolves manual platform when manual options provided", () => {
+    process.env["CI"] = "false";
+
+    const platform = resolvePlatform("auto", {
+      sha: "abc123",
+      refName: "main",
+    });
+    expect(platform.type).toBe("manual");
+  });
+
   test("throws when no platform can be auto-resolved", () => {
     process.env["CI"] = "false";
     expect(() => resolvePlatform("auto")).toThrow(
@@ -54,7 +87,11 @@ describe("Platform Resolution", () => {
     );
   });
 
-  test("exports supported platform types", () => {
+  test("exports auto-detectable platform types", () => {
     expect(specificPlatformTypes).toEqual(["github", "gitlab"]);
+  });
+
+  test("exports all platform types including git and manual", () => {
+    expect(allPlatformTypes).toEqual(["github", "gitlab", "git", "manual"]);
   });
 });

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,30 +1,61 @@
 import { style, logger } from "../logging";
+import { GitPlatform } from "./git";
 import { GitHubPlatform } from "./github";
 import { GitLabPlatform } from "./gitlab";
+import { ManualPlatform, type ManualPlatformOptions } from "./manual";
 
 const platformLogger = logger.childLogger("platform");
 
 export interface Platform {
   type: string;
-  isSupported(): boolean;
   getCommitSha(): string;
   getCommitRefName(): string;
   getChangeRequestIdentifier(): string | undefined;
   getGitTag(): string | undefined;
 }
 
-export const platforms = Object.fromEntries(
+export interface AutoDetectablePlatform extends Platform {
+  isSupported(): boolean;
+}
+
+export const autoDetectablePlatforms = Object.fromEntries(
   [new GitHubPlatform(), new GitLabPlatform()].map((a) => [a.type, a]),
 );
 
-export const specificPlatformTypes = Object.keys(platforms);
+export const specificPlatformTypes = Object.keys(autoDetectablePlatforms);
 
-export function resolvePlatform(platformType: string): Platform {
+export const allPlatformTypes = [...specificPlatformTypes, "git", "manual"];
+
+export function resolvePlatform(
+  platformType: string,
+  manualOpts?: ManualPlatformOptions,
+): Platform {
   if (platformType === "auto") {
+    if (manualOpts) {
+      platformLogger.info(
+        `Resolved platform: ${style.white.bold("manual")} (manual options provided)`,
+      );
+      return new ManualPlatform(manualOpts);
+    }
     return resolveAutoPlatform();
   }
 
-  const platform = platforms[platformType];
+  if (platformType === "git") {
+    platformLogger.info(`Resolved platform: ${style.white.bold("git")}`);
+    return new GitPlatform();
+  }
+
+  if (platformType === "manual") {
+    if (!manualOpts) {
+      throw new Error(
+        "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
+      );
+    }
+    platformLogger.info(`Resolved platform: ${style.white.bold("manual")}`);
+    return new ManualPlatform(manualOpts);
+  }
+
+  const platform = autoDetectablePlatforms[platformType];
   if (!platform) {
     throw new Error(`Unknown platform: ${platformType}`);
   }
@@ -36,7 +67,7 @@ function resolveAutoPlatform(): Platform {
   platformLogger.debug("Resolving platform automatically");
 
   const platformType = specificPlatformTypes.find((t) =>
-    platforms[t].isSupported(),
+    autoDetectablePlatforms[t].isSupported(),
   );
 
   if (!platformType) {
@@ -45,5 +76,5 @@ function resolveAutoPlatform(): Platform {
 
   platformLogger.info(`Resolved platform: ${style.white.bold(platformType)}`);
 
-  return platforms[platformType];
+  return autoDetectablePlatforms[platformType];
 }

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -36,10 +36,11 @@ export function resolvePlatform(
 ): Platform {
   if (platformType === "auto") {
     if (manualOpts) {
+      const platform = new ManualPlatform(manualOpts);
       platformLogger.info(
         `Resolved platform: ${style.white.bold("manual")} (manual options provided)`,
       );
-      return new ManualPlatform(manualOpts);
+      return platform;
     }
     return resolveAutoPlatform();
   }
@@ -53,8 +54,9 @@ export function resolvePlatform(
     if (!manualOpts) {
       throw new Error(MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR);
     }
+    const platform = new ManualPlatform(manualOpts);
     platformLogger.info(`Resolved platform: ${style.white.bold("manual")}`);
-    return new ManualPlatform(manualOpts);
+    return platform;
   }
 
   const platform = autoDetectablePlatforms[platformType];

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -2,7 +2,11 @@ import { style, logger } from "../logging";
 import { GitPlatform } from "./git";
 import { GitHubPlatform } from "./github";
 import { GitLabPlatform } from "./gitlab";
-import { ManualPlatform, type ManualPlatformOptions } from "./manual";
+import {
+  MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR,
+  ManualPlatform,
+  type ManualPlatformOptions,
+} from "./manual";
 
 const platformLogger = logger.childLogger("platform");
 
@@ -47,9 +51,7 @@ export function resolvePlatform(
 
   if (platformType === "manual") {
     if (!manualOpts) {
-      throw new Error(
-        "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
-      );
+      throw new Error(MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR);
     }
     platformLogger.info(`Resolved platform: ${style.white.bold("manual")}`);
     return new ManualPlatform(manualOpts);

--- a/src/platform/manual.test.ts
+++ b/src/platform/manual.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import { ManualPlatform } from "./manual";
+
+describe("Manual Platform", () => {
+  test("identifies as manual platform", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "main",
+    });
+    expect(platform.type).toBe("manual");
+  });
+
+  test("returns provided commit SHA", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123def456",
+      refName: "main",
+    });
+    expect(platform.getCommitSha()).toBe("abc123def456");
+  });
+
+  test("returns provided ref name", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "feature/test",
+    });
+    expect(platform.getCommitRefName()).toBe("feature/test");
+  });
+
+  test("returns provided git tag", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "main",
+      tag: "v1.0.0",
+    });
+    expect(platform.getGitTag()).toBe("v1.0.0");
+  });
+
+  test("returns undefined for git tag when not provided", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "main",
+    });
+    expect(platform.getGitTag()).toBeUndefined();
+  });
+
+  test("returns provided change request identifier", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "main",
+      changeRequestId: "pr-42",
+    });
+    expect(platform.getChangeRequestIdentifier()).toBe("pr-42");
+  });
+
+  test("returns undefined for change request identifier when not provided", () => {
+    const platform = new ManualPlatform({
+      sha: "abc123",
+      refName: "main",
+    });
+    expect(platform.getChangeRequestIdentifier()).toBeUndefined();
+  });
+
+  test("throws when commit SHA is missing", () => {
+    expect(
+      () =>
+        new ManualPlatform({
+          sha: "",
+          refName: "main",
+        }),
+    ).toThrow(
+      "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
+    );
+  });
+
+  test("throws when ref name is missing", () => {
+    expect(
+      () =>
+        new ManualPlatform({
+          sha: "abc123",
+          refName: "",
+        }),
+    ).toThrow(
+      "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
+    );
+  });
+});

--- a/src/platform/manual.test.ts
+++ b/src/platform/manual.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { ManualPlatform } from "./manual";
+import {
+  MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR,
+  ManualPlatform,
+} from "./manual";
 
 describe("Manual Platform", () => {
   test("identifies as manual platform", () => {
@@ -68,9 +71,7 @@ describe("Manual Platform", () => {
           sha: "",
           refName: "main",
         }),
-    ).toThrow(
-      "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
-    );
+    ).toThrow(MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR);
   });
 
   test("throws when ref name is missing", () => {
@@ -80,8 +81,6 @@ describe("Manual Platform", () => {
           sha: "abc123",
           refName: "",
         }),
-    ).toThrow(
-      "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
-    );
+    ).toThrow(MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR);
   });
 });

--- a/src/platform/manual.ts
+++ b/src/platform/manual.ts
@@ -7,14 +7,15 @@ export interface ManualPlatformOptions {
   changeRequestId?: string;
 }
 
+export const MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR =
+  "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)";
+
 export class ManualPlatform implements Platform {
   type = "manual";
 
   constructor(private opts: ManualPlatformOptions) {
     if (!opts.sha || !opts.refName) {
-      throw new Error(
-        "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
-      );
+      throw new Error(MANUAL_PLATFORM_REQUIRED_OPTIONS_ERROR);
     }
   }
 

--- a/src/platform/manual.ts
+++ b/src/platform/manual.ts
@@ -1,0 +1,36 @@
+import type { Platform } from "../platform";
+
+export interface ManualPlatformOptions {
+  sha: string;
+  refName: string;
+  tag?: string;
+  changeRequestId?: string;
+}
+
+export class ManualPlatform implements Platform {
+  type = "manual";
+
+  constructor(private opts: ManualPlatformOptions) {
+    if (!opts.sha || !opts.refName) {
+      throw new Error(
+        "Manual platform requires --commit-sha and --ref-name (or GTS_COMMIT_SHA and GTS_REF_NAME)",
+      );
+    }
+  }
+
+  getCommitSha(): string {
+    return this.opts.sha;
+  }
+
+  getCommitRefName(): string {
+    return this.opts.refName;
+  }
+
+  getGitTag(): string | undefined {
+    return this.opts.tag;
+  }
+
+  getChangeRequestIdentifier(): string | undefined {
+    return this.opts.changeRequestId;
+  }
+}

--- a/src/version/versionResolver.test.ts
+++ b/src/version/versionResolver.test.ts
@@ -20,7 +20,6 @@ mock.module("../util/git", () => ({
 function createMockPlatform(overrides: Partial<Platform> = {}): Platform {
   return {
     type: "test",
-    isSupported: () => true,
     getCommitSha: () => "abc123",
     getCommitRefName: () => "main",
     getGitTag: () => undefined,

--- a/test/e2e/git-that-semver.e2e.test.ts
+++ b/test/e2e/git-that-semver.e2e.test.ts
@@ -667,6 +667,188 @@ output:
     });
   });
 
+  describe("Git Platform", () => {
+    it("snapshot build - untagged commit", async () => {
+      testRepo = await createTestRepo({
+        commits: [
+          { message: "initial", tag: "v1.0.0" },
+          { message: "feature work" },
+        ],
+      });
+
+      const result = await runGTS(
+        ["--platform", "git", "-e", "docker", "-e", "npm"],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_SNAPSHOT_VERSION"]).toBe("true");
+      expect(env["GTS_IS_TAGGED_VERSION"]).toBe("false");
+      expect(env["GTS_DOCKER_VERSION"]).toMatch(
+        /^1\.1\.0-20250115120000\.[0-9a-f]{12}$/,
+      );
+      expect(env["GTS_NPM_VERSION"]).toMatch(
+        /^1\.1\.0-20250115120000\.[0-9a-f]{12}$/,
+      );
+    });
+
+    it("release version - tagged commit", async () => {
+      testRepo = await createTestRepo({
+        commits: [{ message: "release", tag: "v1.0.0" }],
+      });
+
+      const result = await runGTS(
+        ["--platform", "git", "-e", "docker", "-e", "npm"],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_SNAPSHOT_VERSION"]).toBe("false");
+      expect(env["GTS_IS_TAGGED_VERSION"]).toBe("true");
+      expect(env["GTS_IS_SEMVER_VERSION"]).toBe("true");
+      expect(env["GTS_IS_RELEASE_SEMVER_VERSION"]).toBe("true");
+      expect(env["GTS_IS_HIGHEST_SEMVER_VERSION"]).toBe("true");
+      expect(env["GTS_IS_HIGHEST_SEMVER_RELEASE_VERSION"]).toBe("true");
+      expect(env["GTS_DOCKER_VERSION"]).toBe("1.0.0");
+      expect(env["GTS_NPM_VERSION"]).toBe("1.0.0");
+    });
+  });
+
+  describe("Manual Platform", () => {
+    it("snapshot build via CLI flags", async () => {
+      testRepo = await createTestRepo({
+        commits: [
+          { message: "initial", tag: "v1.0.0" },
+          { message: "feature work" },
+        ],
+      });
+      const sha = testRepo.shas[1];
+
+      const result = await runGTS(
+        [
+          "--commit-sha",
+          sha,
+          "--ref-name",
+          "main",
+          "-e",
+          "docker",
+          "-e",
+          "npm",
+        ],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_SNAPSHOT_VERSION"]).toBe("true");
+      expect(env["GTS_IS_TAGGED_VERSION"]).toBe("false");
+      expect(env["GTS_DOCKER_VERSION"]).toMatch(
+        /^1\.1\.0-20250115120000\.[0-9a-f]{12}$/,
+      );
+    });
+
+    it("release version via CLI flags", async () => {
+      testRepo = await createTestRepo({
+        commits: [{ message: "release", tag: "v2.0.0" }],
+      });
+      const sha = testRepo.shas[0];
+
+      const result = await runGTS(
+        [
+          "--commit-sha",
+          sha,
+          "--ref-name",
+          "main",
+          "--git-tag",
+          "v2.0.0",
+          "-e",
+          "docker",
+        ],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_TAGGED_VERSION"]).toBe("true");
+      expect(env["GTS_IS_SEMVER_VERSION"]).toBe("true");
+      expect(env["GTS_DOCKER_VERSION"]).toBe("2.0.0");
+    });
+
+    it("explicit --platform manual", async () => {
+      testRepo = await createTestRepo({
+        commits: [{ message: "initial" }],
+      });
+      const sha = testRepo.shas[0];
+
+      const result = await runGTS(
+        [
+          "--platform",
+          "manual",
+          "--commit-sha",
+          sha,
+          "--ref-name",
+          "develop",
+          "-e",
+          "npm",
+        ],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_SNAPSHOT_VERSION"]).toBe("true");
+    });
+
+    it("errors when manual platform missing required flags", async () => {
+      testRepo = await createTestRepo({
+        commits: [{ message: "initial" }],
+      });
+
+      const result = await runGTS(
+        ["--platform", "manual", "-e", "npm"],
+        {},
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("--commit-sha");
+      expect(result.stderr).toContain("--ref-name");
+    });
+
+    it("manual via GTS env vars", async () => {
+      testRepo = await createTestRepo({
+        commits: [{ message: "initial", tag: "v1.0.0" }, { message: "work" }],
+      });
+      const sha = testRepo.shas[1];
+
+      const result = await runGTS(
+        ["-e", "npm"],
+        {
+          GTS_COMMIT_SHA: sha,
+          GTS_REF_NAME: "main",
+        },
+        testRepo.path,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const env = parseEnvOutput(result.stdout);
+
+      expect(env["GTS_IS_SNAPSHOT_VERSION"]).toBe("true");
+    });
+  });
+
   describe("real repo - date parsing", () => {
     // Tests against a known commit in this repo to verify real git date parsing
     // works correctly (not just the synthetic dates in temp repos).


### PR DESCRIPTION
## Summary

Adds two new platform types that enable GTS to run outside GitHub Actions and GitLab CI:

- **`git` platform** (`--platform git`): reads commit metadata directly from git commands — no env vars needed. Ideal for local development and unsupported CI systems.
- **`manual` platform**: accepts commit info via CLI flags (`--commit-sha`, `--ref-name`, `--git-tag`, `--change-request-id`) or `GTS_` env vars. Auto-activates when any manual flag is present with `platform: auto`.

### Architecture changes

- Split `Platform` interface: `isSupported()` moved to `AutoDetectablePlatform`, implemented only by GitHub/GitLab adapters
- Auto-detection (`platform: auto`) still only considers CI platforms — no silent fallback
- New CLI options: `--platform`, `--commit-sha`, `--ref-name`, `--git-tag`, `--change-request-id`

Closes #62

## Test plan

- [x] Unit tests for `GitPlatform` (SHA format, branch name, tag detection, no change request)
- [x] Unit tests for `ManualPlatform` (all fields, optional fields, validation errors)
- [x] Updated `index.test.ts` (git/manual resolution, auto-detect with manual opts, allPlatformTypes export)
- [x] E2e tests for git platform (snapshot + tagged builds)
- [x] E2e tests for manual platform (CLI flags, env vars, explicit --platform manual, missing required flags error)
- [x] Existing tests unchanged and passing (201 total)